### PR TITLE
chore: sync with upstream geerlingguy/mac-dev-playbook

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Uninstall GitHub Actions' built-in Homebrew.
         run: tests/uninstall-homebrew.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.
         uses: actions/setup-python@v6
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Uninstall GitHub Actions' built-in Homebrew.
         run: tests/uninstall-homebrew.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python 3.
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python 3.
         uses: actions/setup-python@v5
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Uninstall GitHub Actions' built-in Homebrew.
         run: tests/uninstall-homebrew.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@
 name: CI
 'on':
   pull_request:
+    paths-ignore:
+      - '*.md' # Markdown docs need no linting/testing etc.
   push:
+    paths-ignore:
+      - '*.md'
     branches:
       - master
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
     strategy:
       matrix:
         os:
+          - macos-26
           - macos-15
-          - macos-14
 
     steps:
       - name: Check out the codebase.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           days-before-stale: 120
           days-before-close: 60

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v9
         with:
           days-before-stale: 120
           days-before-close: 60

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This playbook installs and configures most of the software I use on my Mac for w
 
 You can use this playbook to manage other Macs as well; the playbook doesn't even need to be run from a Mac at all! If you want to manage a remote Mac, either another Mac on your network, or a hosted Mac like the ones from [MacStadium](https://www.macstadium.com), you just need to make sure you can connect to it with SSH:
 
-  1. (On the Mac you want to connect to:) Go to System Preferences > Sharing.
+  1. (On the Mac you want to connect to:) Go to System Settings > Sharing.
   2. Enable 'Remote Login'.
 
 > You can also enable remote login on the command line:

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,5 +2,5 @@
 nocows = True
 roles_path = ./roles:/etc/ansible/roles
 inventory = inventory
-become = true
+become = True
 stdout_callback = yaml

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,4 +3,4 @@ nocows = True
 roles_path = ./roles:/etc/ansible/roles
 inventory = inventory
 become = True
-result_format = yaml
+callback_result_format = yaml

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,4 +3,4 @@ nocows = True
 roles_path = ./roles:/etc/ansible/roles
 inventory = inventory
 become = True
-stdout_callback = yaml
+result_format = yaml

--- a/default.config.yml
+++ b/default.config.yml
@@ -2,6 +2,9 @@
 configure_dotfiles: true
 configure_terminal: true
 configure_osx: true
+configure_oh_my_zsh: false
+configure_iterm: false
+configure_asdf: false
 
 # Set to 'true' to configure the Dock via dockutil.
 configure_dock: false

--- a/main.yml
+++ b/main.yml
@@ -20,7 +20,7 @@
       when: configure_dotfiles
       tags: ['dotfiles']
     - role: geerlingguy.mac.mas
-      when: mas_installed_apps or mas_installed_app_ids
+      when: (mas_installed_apps | bool) or (mas_installed_app_ids | bool)
       tags: ['mas']
     - role: geerlingguy.mac.dock
       when: configure_dock

--- a/main.yml
+++ b/main.yml
@@ -20,7 +20,7 @@
       when: configure_dotfiles
       tags: ['dotfiles']
     - role: geerlingguy.mac.mas
-      when: (mas_installed_apps | bool) or (mas_installed_app_ids | bool)
+      when: (mas_installed_apps | length > 0) or (mas_installed_app_ids | length > 0)
       tags: ['mas']
     - role: geerlingguy.mac.dock
       when: configure_dock

--- a/tasks/oh-my-zsh.yml
+++ b/tasks/oh-my-zsh.yml
@@ -5,10 +5,11 @@
   git:
     repo: https://github.com/robbyrussell/oh-my-zsh.git
     dest: ~/.oh-my-zsh
+    version: master
     update: false
 
 - name: Change default shell to zsh
   user:
-    name: "{{ansible_user_id}}"
+    name: "{{ ansible_user_id }}"
     shell: /bin/zsh
   become: true


### PR DESCRIPTION
Merges 12 upstream commits (`4dc3352..b775be2`) into the fork.

## What's included
- **dependabot**: new `.github/dependabot.yml`
- **CI**: `paths-ignore` for markdown-only changes, `actions/checkout` + `setup-python` bumped to v6, `stale.yml` tweak
- **ansible.cfg**: `become` capitalization fix + yaml result format
- **main.yml**: `mas` role `when:` now uses `| length > 0` guards
- **README**: 'System Preferences' to 'System Settings'

## Conflict resolution
Merge auto-resolved cleanly. `ci.yml` kept our `schedule:` removal alongside upstream's new `paths-ignore`; our custom README header and `main.yml` `import_tasks` blocks (oh-my-zsh, iterm, asdf) are preserved.

## Note (not addressed here)
The CI `push:` trigger still targets `branches: [master]`; your default is `blimmer-main`, so push-triggered CI won't fire on the fork. Pre-existing; can be a follow-up.