### PR TITLE
New machine prep: sync config, Claude Code setup, day-one repos, declarative macOS defaults

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,6 +8,14 @@ configure_oh_my_zsh: true
 
 configure_iterm: true
 configure_asdf: true
+configure_claude: true
+
+claude_config_repo: git@github.com:blimmer/claude-config.git
+claude_config_repo_version: main
+claude_config_local_destination: ~/.claude
+
+uv_tools:
+  - nah
 
 dotfiles_repo: https://github.com/blimmer/dotfiles
 dotfiles_repo_version: main

--- a/config.yml
+++ b/config.yml
@@ -17,6 +17,13 @@ claude_config_local_destination: ~/.claude
 uv_tools:
   - nah
 
+configure_repos: true
+personal_repos_destination: ~/code
+personal_repos:
+  - git@github.com:blimmer/notes.git
+  - git@github.com:blimmer/scripts.git
+  - git@github.com:blimmer/backup.git
+
 dotfiles_repo: https://github.com/blimmer/dotfiles
 dotfiles_repo_version: main
 dotfiles_repo_accept_hostkey: false

--- a/config.yml
+++ b/config.yml
@@ -32,7 +32,6 @@ dotfiles_files:
   - .asdfrc
   - .gitconfig
   - .gitignore_global
-  - .osx
   - .tool-versions
   - .zshrc
 
@@ -146,6 +145,205 @@ asdf_plugins:
   - bun
   - python
   - just
+
+# General UI/UX
+macos_defaults:
+  - domain: NSGlobalDomain
+    key: NSNavPanelExpandedStateForSaveMode
+    type: bool
+    value: true
+  - domain: NSGlobalDomain
+    key: PMPrintingExpandedStateForPrint
+    type: bool
+    value: true
+  - domain: NSGlobalDomain
+    key: NSDocumentSaveNewDocumentsToCloud
+    type: bool
+    value: false
+  - domain: com.apple.print.PrintingPrefs
+    key: Quit When Finished
+    type: bool
+    value: true
+  - domain: NSGlobalDomain
+    key: NSAutomaticQuoteSubstitutionEnabled
+    type: bool
+    value: false
+  - domain: NSGlobalDomain
+    key: NSAutomaticDashSubstitutionEnabled
+    type: bool
+    value: false
+  - domain: NSGlobalDomain
+    key: NSAutomaticPeriodSubstitutionEnabled
+    type: bool
+    value: false
+  - domain: NSGlobalDomain
+    key: com.apple.sound.uiaudio.enabled
+    type: int
+    value: 0
+  - domain: NSGlobalDomain
+    key: AppleICUForce24HourTime
+    type: bool
+    value: true
+  - domain: com.apple.menuextra.clock
+    key: DateFormat
+    type: string
+    value: "EEE MMM d  H:mm"
+  - domain: com.apple.menuextra.clock
+    key: ShowAMPM
+    type: bool
+    value: false
+  # Trackpad, keyboard, and input
+  - domain: NSGlobalDomain
+    key: ApplePressAndHoldEnabled
+    type: bool
+    value: false
+  - domain: NSGlobalDomain
+    key: InitialKeyRepeat
+    type: int
+    value: 20
+  - domain: NSGlobalDomain
+    key: KeyRepeat
+    type: int
+    value: 1
+  - domain: NSGlobalDomain
+    key: NSAutomaticSpellingCorrectionEnabled
+    type: bool
+    value: false
+  - domain: com.apple.AppleMultitouchTrackpad
+    key: Clicking
+    type: int
+    value: 1
+  - domain: NSGlobalDomain
+    key: com.apple.mouse.tapBehavior
+    type: int
+    value: 1
+    host: currentHost
+  - domain: NSGlobalDomain
+    key: com.apple.mouse.tapBehavior
+    type: int
+    value: 1
+  # Screenshots
+  - domain: com.apple.screencapture
+    key: location
+    type: string
+    value: "{{ ansible_env.HOME }}/screenshots"
+  - domain: com.apple.screencapture
+    key: show-thumbnail
+    type: bool
+    value: false
+  - domain: com.apple.screencapture
+    key: type
+    type: string
+    value: png
+  - domain: com.apple.screencapture
+    key: disable-shadow
+    type: bool
+    value: true
+  # Finder
+  - domain: com.apple.finder
+    key: NewWindowTarget
+    type: string
+    value: PfDe
+  - domain: com.apple.finder
+    key: NewWindowTargetPath
+    type: string
+    value: "file://{{ ansible_env.HOME }}/Desktop/"
+  - domain: com.apple.finder
+    key: ShowExternalHardDrivesOnDesktop
+    type: bool
+    value: true
+  - domain: com.apple.finder
+    key: ShowHardDrivesOnDesktop
+    type: bool
+    value: true
+  - domain: com.apple.finder
+    key: ShowMountedServersOnDesktop
+    type: bool
+    value: true
+  - domain: com.apple.finder
+    key: ShowRemovableMediaOnDesktop
+    type: bool
+    value: true
+  - domain: com.apple.finder
+    key: AppleShowAllFiles
+    type: bool
+    value: true
+  - domain: NSGlobalDomain
+    key: AppleShowAllExtensions
+    type: bool
+    value: true
+  - domain: com.apple.finder
+    key: ShowStatusBar
+    type: bool
+    value: true
+  - domain: com.apple.finder
+    key: _FXShowPosixPathInTitle
+    type: bool
+    value: true
+  - domain: com.apple.finder
+    key: FXDefaultSearchScope
+    type: string
+    value: SCcf
+  - domain: com.apple.finder
+    key: FXEnableExtensionChangeWarning
+    type: bool
+    value: false
+  - domain: NSGlobalDomain
+    key: com.apple.springing.enabled
+    type: bool
+    value: true
+  - domain: NSGlobalDomain
+    key: com.apple.springing.delay
+    type: float
+    value: 0.1
+  - domain: com.apple.desktopservices
+    key: DSDontWriteNetworkStores
+    type: bool
+    value: true
+  - domain: com.apple.finder
+    key: FXPreferredViewStyle
+    type: string
+    value: clmv
+  # Dock and hot corners
+  - domain: com.apple.dock
+    key: tilesize
+    type: float
+    value: 30
+  - domain: com.apple.dock
+    key: expose-animation-duration
+    type: float
+    value: 0.15
+  - domain: com.apple.dock
+    key: showhidden
+    type: bool
+    value: true
+  - domain: com.apple.dock
+    key: show-recents
+    type: bool
+    value: false
+  # Bottom-left hot corner starts the screensaver
+  - domain: com.apple.dock
+    key: wvous-bl-corner
+    type: int
+    value: 5
+  - domain: com.apple.dock
+    key: wvous-bl-modifier
+    type: int
+    value: 0
+  # Don't show desktop when clicking the wallpaper (macOS 14+)
+  - domain: com.apple.WindowManager
+    key: EnableStandardClickToShowDesktop
+    type: bool
+    value: false
+  # Activity Monitor
+  - domain: com.apple.ActivityMonitor
+    key: OpenMainWindow
+    type: bool
+    value: true
+  - domain: com.apple.ActivityMonitor
+    key: ShowCategory
+    type: int
+    value: 0
 
 dockitems_remove:
   - Launchpad

--- a/config.yml
+++ b/config.yml
@@ -23,55 +23,105 @@ dotfiles_files:
 
 homebrew_installed_packages:
   - ack
+  - actionlint
   - asdf
   - awscli
+  - bash
   - bat
+  - bats-core
+  - circleci
+  - contextbridge/tap/aether
   - coreutils
   - curl
+  - fd
   - ffmpeg
+  - findutils
+  - gemini-cli
+  - gh
   - git
+  - git-crypt
+  - git-lfs
+  - gitleaks
+  - gitui
   - go
   - gpg
   - hadolint
   - highlight
+  - hyperfine
+  - imagemagick
+  - jj
   - jq
+  - lefthook
+  - make
+  - mermaid-cli
+  - mkcert
+  - ocrmypdf
   - openssl
+  - pandoc
+  - pinact
+  - pipx
+  - pngcrush
+  - pre-commit
   - python3
+  - rclone
+  - readline
+  - rsync
+  - ruby-build
+  - s3cmd
+  - sccache
   - shellcheck
   - ssh-copy-id
-  - readline
-  - ruby-build
   - tfenv
   - the_silver_searcher
-  - tldr
+  - tlrc
   - tree
+  - typescript-language-server
+  - typos-cli
+  - uv
   - vim
   - wget
+  - yamllint
+  - yq
+  - zizmor
   - zsh
 
-homebrew_taps: []
+homebrew_taps:
+  - contextbridge/tap
 
 homebrew_cask_appdir: /Applications
 homebrew_cask_apps:
   - 1password
-  - aws-vault
+  - 1password-cli
+  - antigravity-cli
+  - aws-vault-binary
+  - brave-browser
   - chatgpt
+  - claude
+  - codex
+  - contextbridge/tap/cli@alpha
   - cursor
-  - docker
+  - docker-desktop
   - firefox@beta
   - font-menlo-for-powerline
+  - gcloud-cli
+  - github
   - google-chrome
   - imageoptim
   - istat-menus
   - iterm2
   - keepingyouawake
+  - logi-options+
+  - loom
+  - netnewswire
   - obsidian
   - pastebot
   - rectangle
+  - session-manager-plugin
   - slack
   - spotify
-  - stretchly
-  - visual-studio-code
+  - tailscale-app
+  - warp
+  - zed
   - zoom
 
 asdf_plugins:
@@ -109,8 +159,8 @@ dockitems_persist:
   - name: Messages
     path: "/System/Applications/Messages.app"
     pos: 2
-  - name: Cursor
-    path: "/Applications/Cursor.app"
+  - name: Zed
+    path: "/Applications/Zed.app"
     pos: 3
   - name: Slack
     path: "/Applications/Slack.app"
@@ -118,9 +168,18 @@ dockitems_persist:
   - name: Spotify
     path: "/Applications/Spotify.app"
     pos: 5
+  - name: NetNewsWire
+    path: "/Applications/NetNewsWire.app"
+    pos: 6
+  - name: Claude
+    path: "/Applications/Claude.app"
+    pos: 7
   - name: ChatGPT
     path: "/Applications/ChatGPT.app"
-    pos: 6
+    pos: 8
+  - name: Warp
+    path: "/Applications/Warp.app"
+    pos: 9
   - name: iTerm
     path: "/Applications/iTerm.app"
-    pos: 7
+    pos: 10

--- a/default.config.yml
+++ b/default.config.yml
@@ -5,6 +5,8 @@ configure_osx: true
 configure_oh_my_zsh: false
 configure_iterm: false
 configure_asdf: false
+configure_claude: false
+uv_tools: []
 
 # Set to 'true' to configure the Dock via dockutil.
 configure_dock: false

--- a/default.config.yml
+++ b/default.config.yml
@@ -9,6 +9,7 @@ configure_claude: false
 uv_tools: []
 configure_repos: false
 personal_repos: []
+macos_defaults: []
 
 # Set to 'true' to configure the Dock via dockutil.
 configure_dock: false

--- a/default.config.yml
+++ b/default.config.yml
@@ -7,6 +7,8 @@ configure_iterm: false
 configure_asdf: false
 configure_claude: false
 uv_tools: []
+configure_repos: false
+personal_repos: []
 
 # Set to 'true' to configure the Dock via dockutil.
 configure_dock: false

--- a/files/capslock-to-escape.plist
+++ b/files/capslock-to-escape.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.blimmer.capslock-to-escape</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/hidutil</string>
+    <string>property</string>
+    <string>--set</string>
+    <string>{"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc":0x700000039,"HIDKeyboardModifierMappingDst":0x700000029}]}</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+</dict>
+</plist>

--- a/full-mac-setup.md
+++ b/full-mac-setup.md
@@ -41,12 +41,14 @@ place.
 1. Re-run the private portion of the playbook:
 
    ```sh
-   ansible-playbook main.yml --tags claude
+   ansible-playbook main.yml --tags claude,repos
    ```
 
    This clones the private [claude-config](https://github.com/blimmer/claude-config)
-   repo into `~/.claude` (settings, hooks, agents, skills, statusline) and
-   installs the uv-managed tools the hooks depend on (`nah`).
+   repo into `~/.claude` (settings, hooks, agents, skills, statusline),
+   installs the uv-managed tools the hooks depend on (`nah`), and clones
+   the day-one personal repos (`notes`, `scripts`, `backup`) into
+   `~/code`.
 
 2. Only now launch Claude Code and sign in. The hooks in `settings.json`
    call `~/.local/bin/nah` on nearly every tool event, so launching before

--- a/full-mac-setup.md
+++ b/full-mac-setup.md
@@ -1,118 +1,83 @@
-# Full Mac Setup Process (for Jeff Geerling)
+# Full Mac Setup Process
 
-There are some things in life that just can't be automated... or aren't 100% worth the time :(
+The steps that can't be (or aren't worth) automating when setting up a new
+Mac, and the order to run everything in. The ordering matters: Claude Code
+must not be launched until its config repo and hook dependencies are in
+place.
 
-This document covers that, at least in terms of setting up a brand new Mac out of the box.
+## Phase 1: Bootstrap (no credentials required)
 
-## Initial configuration of a brand new Mac
+1. Complete the macOS setup wizard. **Name the user account `blimmer`** —
+   the Claude Code hooks reference absolute `/Users/blimmer` paths.
+2. Install Ansible (see [README.md](README.md)).
+3. Clone this playbook over HTTPS (it's public, so no keys needed):
 
-Before starting, I completed Apple's mandatory macOS setup wizard (creating a local user account, and optionally signing into my iCloud account). Once on the macOS desktop, I do the following (in order):
+   ```sh
+   git clone https://github.com/blimmer/mac-dev-playbook.git ~/code/mac-dev-playbook
+   cd ~/code/mac-dev-playbook
+   ansible-galaxy install -r requirements.yml
+   ```
 
-  - Install Ansible (following the guide in [README.md](README.md))
-  - **Sign in to App Store** (since `mas` can't sign in automatically)
-  - Clone mac-dev-playbook to the Mac: `git clone git@github.com:geerlingguy/mac-dev-playbook.git`
-  - Drop `config.yml` from `~/Dropbox/Apps/Config` to the playbook (copy over the network or using a USB flash drive).
-  - Run the playbook.
-    - If there are errors, you may need to finish up other tasks like installing 'old-fashioned' apps first (since I try to place Photoshop in the Dock and it can't be installed automatically). Then, run the playbook again ;)
-  - Start Synchronization tasks:
-    - Open Photos and make sure iCloud sync options are correct
-    - Open Music, make sure computer is authorized, and set Library sync options
-    - Open Dropbox, sign in, and set up sync
-  - Install or complete setup for old-fashioned apps:
-    - Open Creative Cloud, sign in, and install needed apps
-    - Open iStat Menus and configure CPU/Net/Temp Combined view
-    - (If required:)
-      - Install [Elgato Stream Deck](https://www.elgato.com/en/downloads)
-        - Open Livestream profile inside `~/Dropbox/Apps/Config/Stream Deck`
-      - Install [Elgato Key Light Air (Control Center)](https://www.elgato.com/en/downloads)
-      - Install [Autodesk Fusion 360](https://www.autodesk.com)
-      - Install Microsoft Office Home & Student 2019 (https://account.microsoft.com/services/)
-      - Install [Fritzing](https://fritzing.org/download/)
-  - Configure FastMail account:
-    - Log into Fastmail
-    - Go to settings, then Privacy & Security
-    - Create a new app password, and on that page, download the configuration file
-    - Open the downloaded profile, then go to System Preferences, and Device Management
-    - Double-click on the Fastmail profile
-    - Click 'Install...' and install it
-    - Configure which accounts are enabled in the 'Internet Accounts' System Preferences pane
-  - Open Calendar and enable personal Google CalDAV account (you have to manually sign in).
-  - Manually copy `~/Development` folder from another Mac (to save time).
-  - Manual settings to automate someday:
-    - Finder:
-      - Disable click-to-show Desktop: `defaults write com.apple.WindowManager EnableStandardClickToShowDesktop -bool false`
-    - System Preferences:
-      - Accessibility > Display > Reduce transparency
-      - Keyboard > Keyboard Shortcuts... > Modifier Keys... > Caps Lock to Esc
-      - Keyboard > Key repeat rate to 'Fast', Delay until repeat to 'Short'
-      - Privacy & Security > Full Disk Access > enable "Terminal"
-    - Safari:
-      - View > Show Status Bar
-      - Preferences > Advanced > "Show full website address"
-      - Preferences > Advanced > "Show features for web developers"
-      - Install the 'Return YouTube Dislike' Userscript in Userscripts
-    - Dock:
-      - Add jgeerling, Downloads, Applications, and shared "mercury" folders
-  - Final Cut Pro
-    - Install FxFactory and sign in: https://fxfactory.com
-    - Copy contents of `~/Development/youtube/fcpx` into respective directories
-  - These things might be automatable, but I do them manually right now:
-    - Configure Time Machine backup drive
-    - Install Wireguard VPN configurations (if needed)
+4. Run the playbook:
 
-## To Wrap in Post-provision automation
+   ```sh
+   ansible-playbook main.yml --ask-become-pass
+   ```
 
-The following tasks have to wait for the initial Dropbox sync to complete before they'll succeed. So ideally I'll stick this all in a post-provision script but somehow flag it not to run on first provision.
+   This installs Homebrew packages, casks, dotfiles, asdf, the Dock layout,
+   and macOS settings. The Claude config step detects that GitHub SSH auth
+   isn't set up yet, prints a warning, and skips itself — that's expected on
+   the first run.
 
-```
-# ZSH Aliases.
-ln -s /Users/jgeerling/Dropbox/Apps/Config/.aliases /Users/jgeerling/.aliases
+## Phase 2: GitHub auth via 1Password
 
-# Electrum BTC Wallet (open Electrum first).
-ln -s /Users/jgeerling/Dropbox/Apps/Electrum/default_wallet /Users/jgeerling/.electrum/wallets/default_wallet
+1. Open 1Password (installed by the playbook) and sign in.
+2. Enable the SSH agent: Settings → Developer → "Use the SSH agent" (and
+   "Integrate with 1Password CLI" while you're there).
+3. Verify: `ssh -T git@github.com` should greet you by username.
 
-# SSH setup.
-ssh-keygen  # and create a default key to set up .ssh folder
-sudo ln -s /Users/jgeerling/Dropbox/Apps/Config/ssh/config ~/.ssh/config
-# TODO - Manually copy any shared SSH keys that are needed.
+## Phase 3: Claude Code / agents setup
 
-# Ansible setup.
-sudo mkdir -p /etc/ansible
-sudo ln -s /Users/jgeerling/Dropbox/Apps/Config/ansible/ansible.cfg /etc/ansible/ansible.cfg
-sudo ln -s /Users/jgeerling/Dropbox/Apps/Config/ansible/hosts /etc/ansible/hosts
-sudo ln -s /Users/jgeerling/Dropbox/VMs/roles /etc/ansible/roles
-mkdir -p /Users/jgeerling/.ansible
-ln -s /Users/jgeerling/Dropbox/Apps/Config/ansible/galaxy_token /Users/jgeerling/.ansible/galaxy_token
-ln -s /Users/jgeerling/Dropbox/Apps/Config/ansible/mm-vault-password.txt /Users/jgeerling/.ansible/mm-vault-password.txt
-ln -s /Users/jgeerling/Dropbox/VMs/ansible_collections /Users/jgeerling/.ansible/collections
+1. Re-run the private portion of the playbook:
 
-# Final Cut Pro setup. (Open Motion first)
-cp -r /Users/jgeerling/Dropbox/Apps/Config/Motion/Motion\ Templates.localized/ /Users/jgeerling/Movies/Motion\ Templates.localized/
-cp -r /Users/jgeerling/Dropbox/Apps/Config/Motion/Text\ Styles/ /Users/jgeerling/Library/Application\ Support/Motion/Library/Text\ Styles.localized/
+   ```sh
+   ansible-playbook main.yml --tags claude
+   ```
 
-# Sequel Ace favorites. (Open Sequel Ace first)
-cp /Users/jgeerling/Dropbox/Apps/Config/Sequel\ Ace/Favorites.plist /Users/jgeerling/Library/Containers/com.sequel-ace.sequel-ace/Data/Library/Application\ Support/Sequel\ Ace/Data/Favorites.plist
+   This clones the private [claude-config](https://github.com/blimmer/claude-config)
+   repo into `~/.claude` (settings, hooks, agents, skills, statusline) and
+   installs the uv-managed tools the hooks depend on (`nah`).
 
-# Font setup.
-cp ~/Dropbox/Apps/Config/Fonts/* ~/Library/Fonts/
+2. Only now launch Claude Code and sign in. The hooks in `settings.json`
+   call `~/.local/bin/nah` on nearly every tool event, so launching before
+   Phase 3 completes means a broken session and a populated, unmanaged
+   `~/.claude` directory.
+3. Sign in to `gh` so private plugin marketplaces resolve:
 
-# Vim setup.
-mkdir -p ~/.vim/autoload
-mkdir -p ~/.vim/bundle
-cd ~/.vim/autoload
-curl https://raw.githubusercontent.com/tpope/vim-pathogen/master/autoload/pathogen.vim > pathogen.vim
-cd ~/.vim/bundle
-git clone https://github.com/preservim/nerdtree.git
-```
+   ```sh
+   gh auth login
+   ```
 
-## When formatting old Mac
+4. In Claude Code, confirm plugins load (`/plugins`) — the marketplaces
+   include private ContextBridge repos.
 
-  - Sign out of Adobe Creative Cloud
-  - Sign out of Panic Sync in Transmit
-  - Deauthorize Apple Music in iTunes/Music App
-  - Make sure anything new merged into `~/Dropbox/Apps/Config`:
-    - Fonts from ~/Library/Fonts
-    - Motion Plugins from ~/Movies/Motion
-    - Final Cut Pro Text Styles in ~/Library/Application Support/Motion/Library/Text Styles
-    - Sequel Ace shortcuts from ~/Library/Containers/com.sequel-ace.sequel-ace/Data/Library/Application\ Support/Sequel\ Ace/Data/Favorites.plist
-  - Follow Apple's guide [here](https://support.apple.com/en-au/HT212749)
+## Phase 4: Manual sign-ins and licenses
+
+- App Store account
+- Browsers (Firefox, Chrome, Brave) and their sync accounts
+- Slack workspaces
+- Docker Desktop
+- Tailscale
+- Spotify, Obsidian sync
+- iStat Menus license
+- Pastebot accessibility permissions
+- System Settings → Privacy & Security → Full Disk Access → enable
+  terminal apps (Warp, iTerm)
+
+## Notes
+
+- Nothing in the playbook uninstalls software; it only ensures listed items
+  are present.
+- `config.yml` is the single source of truth for packages, casks, taps,
+  asdf plugins, uv tools, and the Dock. When installing something new that
+  should survive a machine move, add it there too.

--- a/main.yml
+++ b/main.yml
@@ -51,9 +51,17 @@
     - import_tasks: tasks/asdf.yml
       when: configure_asdf
 
+    - import_tasks: tasks/github-ssh-check.yml
+      when: configure_claude or configure_repos
+      tags: ['claude', 'repos']
+
     - import_tasks: tasks/claude.yml
       when: configure_claude
       tags: ['claude']
+
+    - import_tasks: tasks/repos.yml
+      when: configure_repos
+      tags: ['repos']
 
     - import_tasks: tasks/sublime-text.yml
       when: configure_sublime

--- a/main.yml
+++ b/main.yml
@@ -12,6 +12,18 @@
         - "{{ playbook_dir }}/config.yml"
       tags: ['always']
 
+  handlers:
+    - name: Apply Caps Lock to Escape mapping
+      ansible.builtin.command:
+        argv:
+          - /usr/bin/hidutil
+          - property
+          - --set
+          - >-
+            {"UserKeyMapping":[{"HIDKeyboardModifierMappingSrc":0x700000039,
+            "HIDKeyboardModifierMappingDst":0x700000029}]}
+      changed_when: true
+
   roles:
     - role: elliotweiser.osx-command-line-tools
     - role: geerlingguy.mac.homebrew

--- a/main.yml
+++ b/main.yml
@@ -51,6 +51,10 @@
     - import_tasks: tasks/asdf.yml
       when: configure_asdf
 
+    - import_tasks: tasks/claude.yml
+      when: configure_claude
+      tags: ['claude']
+
     - import_tasks: tasks/sublime-text.yml
       when: configure_sublime
       tags: ['sublime-text']

--- a/tasks/claude.yml
+++ b/tasks/claude.yml
@@ -1,32 +1,10 @@
 ---
-- name: Check GitHub SSH authentication.
-  ansible.builtin.command: >-
-    ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new
-    -T git@github.com
-  register: github_ssh_check
-  changed_when: false
-  failed_when: false
-
-- name: Determine whether GitHub SSH access is available.
-  ansible.builtin.set_fact:
-    github_ssh_available: >-
-      {{ 'successfully authenticated' in
-         (github_ssh_check.stdout + github_ssh_check.stderr) }}
-
-- name: Warn when GitHub SSH access is unavailable.
-  ansible.builtin.debug:
-    msg: >-
-      GitHub SSH authentication is not available, so the private Claude
-      config repo was not cloned. Sign in to 1Password, enable its SSH
-      agent, then re-run with: ansible-playbook main.yml --tags claude
-  when: not github_ssh_available
-
 - name: Ensure the Claude config directory exists.
   ansible.builtin.file:
     path: "{{ claude_config_local_destination }}"
     state: directory
     mode: "0755"
-  when: github_ssh_available
+  when: github_ssh_available | default(false)
 
 # Adopts the repo even if Claude Code already created files in the
 # directory, where a plain `git clone` would refuse to run.
@@ -41,7 +19,7 @@
   args:
     chdir: "{{ claude_config_local_destination }}"
     creates: "{{ claude_config_local_destination }}/.git"
-  when: github_ssh_available
+  when: github_ssh_available | default(false)
 
 - name: Install uv-managed tools.
   ansible.builtin.command: "uv tool install {{ item }}"

--- a/tasks/claude.yml
+++ b/tasks/claude.yml
@@ -1,0 +1,50 @@
+---
+- name: Check GitHub SSH authentication.
+  ansible.builtin.command: >-
+    ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+    -T git@github.com
+  register: github_ssh_check
+  changed_when: false
+  failed_when: false
+
+- name: Determine whether GitHub SSH access is available.
+  ansible.builtin.set_fact:
+    github_ssh_available: >-
+      {{ 'successfully authenticated' in
+         (github_ssh_check.stdout + github_ssh_check.stderr) }}
+
+- name: Warn when GitHub SSH access is unavailable.
+  ansible.builtin.debug:
+    msg: >-
+      GitHub SSH authentication is not available, so the private Claude
+      config repo was not cloned. Sign in to 1Password, enable its SSH
+      agent, then re-run with: ansible-playbook main.yml --tags claude
+  when: not github_ssh_available
+
+- name: Ensure the Claude config directory exists.
+  ansible.builtin.file:
+    path: "{{ claude_config_local_destination }}"
+    state: directory
+    mode: "0755"
+  when: github_ssh_available
+
+# Adopts the repo even if Claude Code already created files in the
+# directory, where a plain `git clone` would refuse to run.
+- name: Clone the Claude config repo into the config directory.
+  ansible.builtin.shell: |
+    set -e
+    git init
+    git remote add origin {{ claude_config_repo }}
+    git fetch origin {{ claude_config_repo_version }}
+    git checkout -f -B {{ claude_config_repo_version }} \
+      origin/{{ claude_config_repo_version }}
+  args:
+    chdir: "{{ claude_config_local_destination }}"
+    creates: "{{ claude_config_local_destination }}/.git"
+  when: github_ssh_available
+
+- name: Install uv-managed tools.
+  ansible.builtin.command: "uv tool install {{ item }}"
+  args:
+    creates: "{{ ansible_env.HOME }}/.local/bin/{{ item }}"
+  loop: "{{ uv_tools }}"

--- a/tasks/github-ssh-check.yml
+++ b/tasks/github-ssh-check.yml
@@ -1,0 +1,22 @@
+---
+- name: Check GitHub SSH authentication.
+  ansible.builtin.command: >-
+    ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new
+    -T git@github.com
+  register: github_ssh_check
+  changed_when: false
+  failed_when: false
+
+- name: Determine whether GitHub SSH access is available.
+  ansible.builtin.set_fact:
+    github_ssh_available: >-
+      {{ 'successfully authenticated' in
+         (github_ssh_check.stdout + github_ssh_check.stderr) }}
+
+- name: Warn when GitHub SSH access is unavailable.
+  ansible.builtin.debug:
+    msg: >-
+      GitHub SSH authentication is not available, so private repos were
+      not cloned. Sign in to 1Password, enable its SSH agent, then re-run
+      with: ansible-playbook main.yml --tags claude,repos
+  when: not github_ssh_available

--- a/tasks/osx.yml
+++ b/tasks/osx.yml
@@ -1,5 +1,55 @@
 ---
-# TODO: Use sudo once .osx can be run via root with no user interaction.
-- name: Run .osx dotfiles.
-  command: "{{ osx_script }}"
+- name: Ensure the screenshots directory exists.
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/screenshots"
+    state: directory
+    mode: "0755"
+
+- name: Set macOS defaults.
+  community.general.osx_defaults:
+    domain: "{{ item.domain }}"
+    host: "{{ item.host | default(omit) }}"
+    key: "{{ item.key }}"
+    type: "{{ item.type }}"
+    value: "{{ item.value }}"
+  loop: "{{ macos_defaults }}"
+  loop_control:
+    label: "{{ item.domain }} {{ item.key }}"
+
+- name: Show the ~/Library folder.
+  ansible.builtin.command: "chflags nohidden {{ ansible_env.HOME }}/Library"
+  changed_when: false
+
+# Remaps at every login via RunAtLoad; the handler covers this session.
+- name: Install the Caps Lock to Escape launch agent.
+  ansible.builtin.copy:
+    src: capslock-to-escape.plist
+    dest: ~/Library/LaunchAgents/com.blimmer.capslock-to-escape.plist
+    mode: "0644"
+  notify: Apply Caps Lock to Escape mapping
+
+# Best-effort, as in the original .osx script: the nested keys only exist
+# once Finder has written its view settings at least once.
+- name: Snap desktop and icon-view icons to a grid.
+  ansible.builtin.command: >-
+    /usr/libexec/PlistBuddy
+    -c "Set :{{ item }}:IconViewSettings:arrangeBy grid"
+    {{ ansible_env.HOME }}/Library/Preferences/com.apple.finder.plist
+  loop:
+    - DesktopViewSettings
+    - FK_StandardViewSettings
+    - StandardViewSettings
+  failed_when: false
+  changed_when: false
+
+- name: Set desktop and icon-view icon size.
+  ansible.builtin.command: >-
+    /usr/libexec/PlistBuddy
+    -c "Set :{{ item }}:IconViewSettings:iconSize 64"
+    {{ ansible_env.HOME }}/Library/Preferences/com.apple.finder.plist
+  loop:
+    - DesktopViewSettings
+    - FK_StandardViewSettings
+    - StandardViewSettings
+  failed_when: false
   changed_when: false

--- a/tasks/repos.yml
+++ b/tasks/repos.yml
@@ -1,0 +1,20 @@
+---
+- name: Ensure the code directory exists.
+  ansible.builtin.file:
+    path: "{{ personal_repos_destination }}"
+    state: directory
+    mode: "0755"
+  when: github_ssh_available | default(false)
+
+# update: false so existing checkouts are never touched on re-runs.
+- name: Clone personal repos.
+  ansible.builtin.git:
+    repo: "{{ item }}"
+    dest: >-
+      {{ personal_repos_destination }}/{{
+         item | basename | regex_replace('\.git$', '') }}
+    version: main
+    accept_hostkey: true
+    update: false
+  loop: "{{ personal_repos }}"
+  when: github_ssh_available | default(false)


### PR DESCRIPTION
## Summary

Prepares the playbook for provisioning a new machine:

- **Sync config with current machine state** — ~40 new formulae in daily use, new casks (Warp, Claude, Zed, etc.), renamed casks fixed, contextbridge/tap added, and the dock layout updated.
- **Provision Claude Code agent setup** — new `claude` tag adopts the private claude-config repo into `~/.claude` and installs uv-managed hook dependencies, skipping gracefully until GitHub SSH auth is available.
- **Clone day-one personal repos** — new `repos` tag clones notes/scripts/backup into `~/code` with update disabled so re-runs never touch local work.
- **Manage macOS defaults declaratively** — replaces the `.osx` dotfiles script with a `macos_defaults` list applied via `community.general.osx_defaults`, drops settings dead on modern macOS, fixes two long-broken lines, and maps Caps Lock → Escape via `hidutil` with a LaunchAgent for persistence.

`full-mac-setup.md` is rewritten as a phased bootstrap: playbook → 1Password SSH agent → `--tags claude,repos` re-run → launch Claude Code.